### PR TITLE
Veracode SCA: fixes for vulnerable libraries

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -19,7 +19,7 @@
 	<properties>
 		<spring.version>4.3.10.RELEASE</spring.version>
 		<springboot.version>2.3.1.RELEASE</springboot.version>
-		<fileupload.version>1.3.2</fileupload.version>
+		<fileupload.version>1.5</fileupload.version>
 	</properties>
 
 	<!-- Dependencies begin here -->
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-saml-core</artifactId>
-			<version>1.8.1.Final</version>
+			<version>2.5.5.Final</version>
 		</dependency>
 
 		<dependency>
@@ -130,7 +130,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-collections4</artifactId>
-			<version>4.0</version>
+			<version>4.1</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
This pull request was generated by Veracode SCA to upgrade the following vulnerable libraries:

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| MAVEN | `commons-fileupload:commons-fileupload` | 1.3.2 | 1.5 | No |
| MAVEN | `org.keycloak:keycloak-saml-core` | 1.8.1.Final | 2.5.5.Final | No |
| MAVEN | `org.apache.commons:commons-collections4` | 4.0 | 4.1 | No |

Note that we only upgrade libraries which have versions without any known vulnerabilities. For more information, please see the corresponding [Veracode SCA report](https://sca.analysiscenter.veracode.com/teams/200td1K/scans/63572729).

The **Breaking** column states the likelihood that updating to the recommended library version will cause breaking changes in your code. Please verify that the changes here won't cause issues with your project before merging.

To learn more about this feature, please visit our [Help Center](https://help.veracode.com/r/About_Automatic_Pull_Requests) for documentation.

Note: this pull request was generated because you or someone else with access to this repository granted Veracode SCA access to submit pull requests.
<!-- srcclr-pr-id-ebc40d2124ba84123baa262808b1032e89caff46ab6075e1352cdecac9c7e130 -->
